### PR TITLE
Update KongAdminExtension.php

### DIFF
--- a/src/DependencyInjection/KongAdminExtension.php
+++ b/src/DependencyInjection/KongAdminExtension.php
@@ -17,19 +17,14 @@ use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
- * kong admin extension
+ * Kong admin extension
  *
  * @author VEBER Arnaud <https://github.com/VEBERArnaud>
  */
 class KongAdminExtension extends Extension
 {
     /**
-     * load
-     *
-     * @param array $configs
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     *
-     * @return void
+     * {@inheritdoc}
      */
     public function load(array $configs, ContainerBuilder $container)
     {


### PR DESCRIPTION
# Description

That's a PHPdoc detail but I think you should have used the short `ContainerBuilder` syntax.

Anyway, you can just use `{@inheritdoc}` as PHPdoc is already specified here: https://github.com/symfony/symfony/blob/master/src/Symfony/Component/DependencyInjection/Extension/ExtensionInterface.php#L31

---

| Q              | A
| -------------- | ---
| Bug fix ?      | no
| New feature ?  | no
| BC breaks ?    | no
| Deprecations ? | no
| Tests pass ?   | yes
| Fixed tickets  | None
| License        | MIT
